### PR TITLE
protect against Tk not having `_default_root` attr during event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+.CondaPkg

--- a/src/pygui.jl
+++ b/src/pygui.jl
@@ -191,6 +191,7 @@ function Tk_eventloop(sec::Real=50e-3)
     flag = _tkinter.ALL_EVENTS | _tkinter.DONT_WAIT
     root = pynothing = Py(nothing)
     install_doevent(sec) do async
+        @show typeof(Tk)
         if pyhasattr(Tk, "_default_root")
             new_root = Tk._default_root
             if pyconvert(Bool, new_root != pynothing)

--- a/src/pygui.jl
+++ b/src/pygui.jl
@@ -191,12 +191,14 @@ function Tk_eventloop(sec::Real=50e-3)
     flag = _tkinter.ALL_EVENTS | _tkinter.DONT_WAIT
     root = pynothing = Py(nothing)
     install_doevent(sec) do async
-        new_root = Tk._default_root
-        if pyconvert(Bool, new_root != pynothing)
-            root = new_root
-        end
-        if pyconvert(Bool, root != pynothing)
-            while pyconvert(Bool, root.dooneevent(flag))
+        if pyhasattr(Tk, "_default_root")
+            new_root = Tk._default_root
+            if pyconvert(Bool, new_root != pynothing)
+                root = new_root
+            end
+            if pyconvert(Bool, root != pynothing)
+                while pyconvert(Bool, root.dooneevent(flag))
+                end
             end
         end
     end


### PR DESCRIPTION
I don't understand why this segfault is happening after the test suite finishes, but this should protect against it?

```
Test Summary:  | Pass  Total     Time
Foofoofoooo.jl |  614    614  5m39.0s
signal (11): Segmentation fault
in expression starting at none:0
_PyInterpreterState_GET at /usr/local/src/conda/python-3.11.0/Include/internal/pycore_pystate.h:116 [inlined]
get_dict_state at /usr/local/src/conda/python-3.11.0/Objects/dictobject.c:251 [inlined]
new_dict at /usr/local/src/conda/python-3.11.0/Objects/dictobject.c:722 [inlined]
PyDict_New at /usr/local/src/conda/python-3.11.0/Objects/dictobject.c:841
type_ready_set_dict at /usr/local/src/conda/python-3.11.0/Objects/typeobject.c:6143 [inlined]
type_ready at /usr/local/src/conda/python-3.11.0/Objects/typeobject.c:6462 [inlined]
PyType_Ready at /usr/local/src/conda/python-3.11.0/Objects/typeobject.c:6513
_PyObject_GenericGetAttrWithDict at /usr/local/src/conda/python-3.11.0/Objects/object.c:1266
PyObject_GenericGetAttr at /usr/local/src/conda/python-3.11.0/Objects/object.c:1367 [inlined]
module_getattro at /usr/local/src/conda/python-3.11.0/Objects/moduleobject.c:761
PyObject_GetAttr at /usr/local/src/conda/python-3.11.0/Objects/object.c:916
PyObject_GetAttr at /home/ubuntu/.julia/packages/PythonCall/dsECZ/src/cpython/pointers.jl:299 [inlined]
pygetattr at /home/ubuntu/.julia/packages/PythonCall/dsECZ/src/abstract/object.jl:60
getproperty at /home/ubuntu/.julia/packages/PythonCall/dsECZ/src/Py.jl:272 [inlined]
#9 at /home/ubuntu/.julia/packages/PythonPlot/f591M/src/pygui.jl:194
macro expansion at ./asyncevent.jl:281 [inlined]
#666 at ./task.jl:134
unknown function (ip: 0x7ff7e519218f)
_jl_invoke at /cache/build/default-amdci4-2/julialang/julia-release-1-dot-8/src/gf.c:2377 [inlined]
ijl_apply_generic at /cache/build/default-amdci4-2/julialang/julia-release-1-dot-8/src/gf.c:2559
jl_apply at /cache/build/default-amdci4-2/julialang/julia-release-1-dot-8/src/julia.h:1843 [inlined]
start_task at /cache/build/default-amdci4-2/julialang/julia-release-1-dot-8/src/task.c:931
Allocations: 838271008 (Pool: 837751882; Big: 519126); GC: 109
```

Unfortunately I can't reproduce this segfault locally, but will check this works