### PR TITLE
Fix precompilation on latest master

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -144,6 +144,7 @@ gui = :default
 # initialization -- anything that depends on Python has to go here,
 # so that it occurs at runtime (while the rest of PythonPlot can be precompiled).
 function __init__()
+    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
     isjulia_display[] = isdisplayok()
     PythonCall.pycopy!(matplotlib, pyimport("matplotlib"))
     mvers = pyconvert(String, matplotlib.__version__)


### PR DESCRIPTION
Use Revise.jl's "trick" that disables `__init__()` when precompiling.

See: https://github.com/timholy/Revise.jl/pull/731

May not be the most idiomatic or best fix in the long term; perhaps the first call to a `PythonPlot` function could initialize the backend instead?

May or may not be related to #25 .