### PR TITLE
fix bugs with pyexists and qt path

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -124,6 +124,7 @@ function find_backend(matplotlib::Py)
             return (gui2matplotlib[gui], gui)
         end
     catch e
+        @warn(e) # provide information for debugging why a gui was not found
         if !isjulia_display[]
             @warn("No working GUI backend found for matplotlib")
             isjulia_display[] = true

--- a/src/pygui.jl
+++ b/src/pygui.jl
@@ -9,7 +9,9 @@
 # global variable to specify default GUI toolkit to use
 gui = :default # one of :default, :wx, :qt, :tk, or :gtk
 
-pyexists(mod::AbstractString) = pyconvert(Bool, pyimport("importlib").util.find_spec(mod) != Py(nothing))
+# for some reason, `util` is not always imported as an attribute to `importlib`:
+#PythonCall.PyException(<py AttributeError("module 'importlib' has no attribute 'util'")>)
+pyexists(mod::AbstractString) = pyconvert(Bool, pyimport("importlib.util").find_spec(mod) != Py(nothing))
 
 pygui_works(gui::Symbol) = gui == :default ||
     ((gui == :wx && pyexists("wx")) ||
@@ -130,7 +132,9 @@ end
 
 # Qt: (PyQt5, PyQt4, or PySide module)
 function qt_eventloop(QtCore::Py, sec::Real=50e-3)
-    fixqtpath()
+    # `fixqtpath()` seems to not be working,
+    # https://github.com/JuliaPy/PythonPlot.jl/issues/17
+    #fixqtpath()
     instance = QtCore.QCoreApplication.instance
     AllEvents = QtCore.QEventLoop.AllEvents
     processEvents = QtCore.QCoreApplication.processEvents


### PR DESCRIPTION
On my system (MacOS with macports-installed julia and python), PythonPlot was not picking up an appropriate gui backend. It took some sleuthing to determine why, but I discovered that `pyimport("importlib")` would sometimes not include `util` as an attribute. This PR fixes that problem, and also adds output of the error in the gui-detection try block to help with any future bugs that might arise there. 

I also include in this PR a change to comment out `fixqtpath()` as it does not seem to work properly, as also reported in #17. I have not spent time chasing this one down. This change enables Qt5 backend on my system, even without specifying `ENV["QT_PLUGIN_PATH"]`.