### PR TITLE
Update deprecated colormap APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ colors in various plot types).  In particular:
 
   * Even more general color maps may be defined by passing arrays of (x,y0,y1) tuples for the red, green, blue, and (optionally) alpha components, as defined by the [matplotlib.colors.LinearSegmentedColormap](http://matplotlib.org/api/colors_api.html#matplotlib.colors.LinearSegmentedColormap) constructor, via: `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, n=256, gamma=1.0)` or `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, alpha::AbstractVector{(T,T,T)}, n=256, gamma=1.0)`
 
-  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.cm.get_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.get_cmap)(`name`).
+  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.pyplot.get_cmap](http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap)(`name`).
 
   * `matplotlib.colors.Colormap` objects returned by Python functions are automatically converted to the `ColorMap` type.
 
-* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.cm.get_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.get_cmap) function.
+* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.pyplot.get_cmap](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap) function.
 
-* `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.cm.register_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.register_cmap) function.
+* `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.colormaps.register](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.register) function.
 
 * `get_cmaps()` returns a `Vector{ColorMap}` of the currently
   registered colormaps.

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -48,8 +48,8 @@ function init_colormaps()
 
     PythonCall.pycopy!(LinearSegmentedColormap, colorsm.LinearSegmentedColormap)
 
-    PythonCall.pycopy!(cm_get_cmap, cm.get_cmap)
-    PythonCall.pycopy!(cm_register_cmap, cm.register_cmap)
+    PythonCall.pycopy!(cm_get_cmap, pyhasattr(pyplot, "get_cmap") ? pyplot.get_cmap : cm.get_cmap)
+    PythonCall.pycopy!(cm_register_cmap, pyhasattr(matplotlib.colormaps, "register") ? matplotlib.colormaps.register : cm.register_cmap)
 
     PythonCall.pycopy!(ScalarMappable, cm.ScalarMappable)
     PythonCall.pycopy!(Normalize01, pycall(colorsm.Normalize; vmin=0,vmax=1))


### PR DESCRIPTION
Similar to https://github.com/JuliaPy/PyPlot.jl/pull/583, but with PythonCall syntaxes.