### PR TITLE
Make sure event loop is terminated when Julia exits

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -178,6 +178,9 @@ function __init__()
     end
 
     init_colormaps()
+
+    # Ensure that the event loop is stopped when the Julia process exits
+    atexit(pygui_stop_all)
 end
 
 function pygui(b::Bool)


### PR DESCRIPTION
This PR is an attempt to fix #45. I believe the issue there is that Julia begins shutdown while the event loop is still running, and this may cause race conditions. Adding an `atexit` hook that stops the GUI seems to on my machine fix the segfault issue.